### PR TITLE
Rettet i RackVM og RackView.xaml.cs

### DIFF
--- a/Reolmarked/View/RackView.xaml.cs
+++ b/Reolmarked/View/RackView.xaml.cs
@@ -1,5 +1,8 @@
 ﻿using System.Windows.Controls;
 using Reolmarked.ViewModel;
+using System.Configuration;
+using Reolmarked.Repositories;
+
 
 namespace Reolmarked.View
 {
@@ -8,7 +11,16 @@ namespace Reolmarked.View
         public RackView()
         {
             InitializeComponent();
-            DataContext = new RackViewModel();
+
+            // Hent connection string fra App.config (navn: ReolmarkedDb)
+            var cs = ConfigurationManager
+                .ConnectionStrings["ReolmarkedDb"]
+                .ConnectionString;
+
+            // Opret repository og giv det til ViewModel
+            var repo = new RackRepository(cs);
+            DataContext = new RackViewModel(repo);
         }
+
     }
 }


### PR DESCRIPTION
I VM har jeg tilføjet:
Tilføjet: using System.Windows.Media; (i stedet for System.Drawing)
 
Tilføjet: using Reolmarked.Repositories;
 
Tilføjet: private readonly IRackRepository _repo;
private System.Collections.Generic.HashSet<int> _occupiedIds = new();
 
Under konstruktør har jeg ændret
signatur fra: public RackViewModel()
til: public RackViewModel(IRackRepository repo)
 
Slettet hele denne:
private static readonly System.Collections.Generic.HashSet<int> OCCUPIED =
    new System.Collections.Generic.HashSet<int>(new[] { 12, 28, 43, 56, 61, 63, 65, 68, 70, 71, 73, 75, 78, 80 });
 
Tilføjet beregning af optagne reoler:
_occupiedIds = Racks
    .Where(r => r.RackStatusId == 2)
    .Select(r => r.RackId)
    .ToHashSet();
 
Ændret RackBackground-settet fra en løs switch til en normal setter:
public Brush RackBackground
{
    get => rackBackGround;
    set
    {
        rackBackGround = value;
        OnPropertyChanged(nameof(RackBackground));
    }
}
 
 
I xaml.cs har jeg tilføjet: 
using System.Configuration;
using Reolmarked.Repositories;
 
Konstruktør ændret til at injicere repository:
var cs = ConfigurationManager.ConnectionStrings["ReolmarkedDb"].ConnectionString;
var repo = new RackRepository(cs);
DataContext = new RackViewModel(repo);